### PR TITLE
Fix invalid supertest import

### DIFF
--- a/bookstore-api-JMarani-main/test/app.e2e-spec.ts
+++ b/bookstore-api-JMarani-main/test/app.e2e-spec.ts
@@ -1,11 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 
 describe('AppController (e2e)', () => {
-  let app: INestApplication<App>;
+  let app: INestApplication;
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({


### PR DESCRIPTION
## Summary
- clean up test to remove invalid App import from supertest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e97cdc608321866616e50941ee2a