### PR TITLE
Add books, authors, publishers and review relations

### DIFF
--- a/bookstore-api-JMarani-main/src/app.module.ts
+++ b/bookstore-api-JMarani-main/src/app.module.ts
@@ -2,6 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { BookReviewModule } from './book-review/book-review.module';
 import { BookReview } from './book-review/book-review.entity';
+import { Autor } from './autor/autor.entity';
+import { Editora } from './editora/editora.entity';
+import { Livro } from './livro/livro.entity';
+import { AutorModule } from './autor/autor.module';
+import { EditoraModule } from './editora/editora.module';
+import { LivroModule } from './livro/livro.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 
@@ -10,11 +16,14 @@ import { AppService } from './app.service';
     TypeOrmModule.forRoot({
       type: 'sqlite',
       database: 'db.sqlite',
-      entities: [BookReview],
-      synchronize: true,   
+      entities: [BookReview, Autor, Editora, Livro],
+      synchronize: true,
       logging: true,
     }),
     BookReviewModule,
+    AutorModule,
+    EditoraModule,
+    LivroModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/bookstore-api-JMarani-main/src/autor/autor.controller.ts
+++ b/bookstore-api-JMarani-main/src/autor/autor.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Post, Get, Patch, Delete, Body, Param, ParseIntPipe } from '@nestjs/common';
+import { AutorService } from './autor.service';
+import { CreateAutorDto } from './dto/create-autor.dto';
+import { UpdateAutorDto } from './dto/update-autor.dto';
+
+@Controller('autores')
+export class AutorController {
+  constructor(private readonly service: AutorService) {}
+
+  @Post()
+  create(@Body() dto: CreateAutorDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.service.findOne(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateAutorDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.service.remove(id);
+  }
+}

--- a/bookstore-api-JMarani-main/src/autor/autor.entity.ts
+++ b/bookstore-api-JMarani-main/src/autor/autor.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
+import { Livro } from '../livro/livro.entity';
+
+@Entity('autores')
+export class Autor {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  nome: string;
+
+  @Column()
+  nacionalidade: string;
+
+  @OneToMany(() => Livro, livro => livro.autor)
+  livros: Livro[];
+}

--- a/bookstore-api-JMarani-main/src/autor/autor.module.ts
+++ b/bookstore-api-JMarani-main/src/autor/autor.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Autor } from './autor.entity';
+import { AutorService } from './autor.service';
+import { AutorController } from './autor.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Autor])],
+  controllers: [AutorController],
+  providers: [AutorService],
+})
+export class AutorModule {}

--- a/bookstore-api-JMarani-main/src/autor/autor.service.ts
+++ b/bookstore-api-JMarani-main/src/autor/autor.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Autor } from './autor.entity';
+import { CreateAutorDto } from './dto/create-autor.dto';
+import { UpdateAutorDto } from './dto/update-autor.dto';
+
+@Injectable()
+export class AutorService {
+  constructor(@InjectRepository(Autor) private repo: Repository<Autor>) {}
+
+  create(dto: CreateAutorDto) {
+    const autor = this.repo.create(dto);
+    return this.repo.save(autor);
+  }
+
+  findAll() {
+    return this.repo.find();
+  }
+
+  async findOne(id: number) {
+    const autor = await this.repo.findOne({ where: { id } });
+    if (!autor) throw new NotFoundException(`Autor #${id} não encontrado`);
+    return autor;
+  }
+
+  async update(id: number, dto: UpdateAutorDto) {
+    const autor = await this.findOne(id);
+    Object.assign(autor, dto);
+    return this.repo.save(autor);
+  }
+
+  async remove(id: number) {
+    const autor = await this.findOne(id);
+    return this.repo.remove(autor);
+  }
+}

--- a/bookstore-api-JMarani-main/src/autor/dto/create-autor.dto.ts
+++ b/bookstore-api-JMarani-main/src/autor/dto/create-autor.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateAutorDto {
+  @IsString() @IsNotEmpty()
+  nome: string;
+
+  @IsString() @IsNotEmpty()
+  nacionalidade: string;
+}

--- a/bookstore-api-JMarani-main/src/autor/dto/update-autor.dto.ts
+++ b/bookstore-api-JMarani-main/src/autor/dto/update-autor.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateAutorDto } from './create-autor.dto';
+
+export class UpdateAutorDto extends PartialType(CreateAutorDto) {}

--- a/bookstore-api-JMarani-main/src/book-review/book-review.controller.ts
+++ b/bookstore-api-JMarani-main/src/book-review/book-review.controller.ts
@@ -3,7 +3,7 @@ import { BookReviewService } from './book-review.service';
 import { CreateBookReviewDto } from './dto/create-book-review.dto';
 import { UpdateBookReviewDto } from './dto/update-book-review.dto';
 
-@Controller('book-reviews')
+@Controller('reviews')
 export class BookReviewController {
   constructor(private readonly service: BookReviewService) {}
 

--- a/bookstore-api-JMarani-main/src/book-review/book-review.entity.ts
+++ b/bookstore-api-JMarani-main/src/book-review/book-review.entity.ts
@@ -1,22 +1,17 @@
-import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+import { Livro } from '../livro/livro.entity';
 
 @Entity('book_reviews')
 export class BookReview {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column()
-  bookTitle: string;
-
-  @Column()
-  reviewerName: string;
-
   @Column('text')
-  reviewText: string;
+  comentario: string;
 
   @Column({ type: 'integer' })
-  rating: number;
+  nota: number;
 
-  @Column({ default: false })
-  recommended: boolean;
+  @ManyToOne(() => Livro, livro => livro.reviews, { onDelete: 'CASCADE' })
+  livro: Livro;
 }

--- a/bookstore-api-JMarani-main/src/book-review/book-review.module.ts
+++ b/bookstore-api-JMarani-main/src/book-review/book-review.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { BookReview } from './book-review.entity';
+import { Livro } from '../livro/livro.entity';
 import { BookReviewRepository } from './book-review.repository';
 import { BookReviewService } from './book-review.service';
 import { BookReviewController } from './book-review.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([BookReview])],
+  imports: [TypeOrmModule.forFeature([BookReview, Livro])],
   controllers: [BookReviewController],
   providers: [BookReviewService, BookReviewRepository],
 })

--- a/bookstore-api-JMarani-main/src/book-review/book-review.service.ts
+++ b/bookstore-api-JMarani-main/src/book-review/book-review.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { Livro } from '../livro/livro.entity';
 import { BookReview } from './book-review.entity';
 import { CreateBookReviewDto } from './dto/create-book-review.dto';
 import { UpdateBookReviewDto } from './dto/update-book-review.dto';
@@ -10,19 +11,27 @@ export class BookReviewService {
   constructor(
     @InjectRepository(BookReview)
     private repo: Repository<BookReview>,
+    @InjectRepository(Livro)
+    private livroRepo: Repository<Livro>,
   ) {}
 
-  create(dto: CreateBookReviewDto) {
-    const review = this.repo.create(dto);
+  async create(dto: CreateBookReviewDto) {
+    const livro = await this.livroRepo.findOne({ where: { id: dto.livroId } });
+    if (!livro) throw new NotFoundException(`Livro #${dto.livroId} não encontrado`);
+    const review = this.repo.create({
+      comentario: dto.comentario,
+      nota: dto.nota,
+      livro,
+    });
     return this.repo.save(review);
   }
 
   findAll() {
-    return this.repo.find();
+    return this.repo.find({ relations: ['livro'] });
   }
 
   async findOne(id: number) {
-    const review = await this.repo.findOne({ where: { id } });
+    const review = await this.repo.findOne({ where: { id }, relations: ['livro'] });
     if (!review) throw new NotFoundException(`Review #${id} não encontrada`);
     return review;
   }

--- a/bookstore-api-JMarani-main/src/book-review/dto/create-book-review.dto.ts
+++ b/bookstore-api-JMarani-main/src/book-review/dto/create-book-review.dto.ts
@@ -1,18 +1,12 @@
-import { IsBoolean, IsInt, IsNotEmpty, IsString, Max, Min } from 'class-validator';
+import { IsInt, IsNotEmpty, IsString, Max, Min } from 'class-validator';
 
 export class CreateBookReviewDto {
   @IsString() @IsNotEmpty()
-  bookTitle: string;
+  comentario: string;
 
-  @IsString() @IsNotEmpty()
-  reviewerName: string;
+  @IsInt() @Min(1) @Max(5)
+  nota: number;
 
-  @IsString() @IsNotEmpty()
-  reviewText: string;
-
-  @IsInt() @Min(0) @Max(5)
-  rating: number;
-
-  @IsBoolean()
-  recommended: boolean;
+  @IsInt()
+  livroId: number;
 }

--- a/bookstore-api-JMarani-main/src/editora/dto/create-editora.dto.ts
+++ b/bookstore-api-JMarani-main/src/editora/dto/create-editora.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateEditoraDto {
+  @IsString() @IsNotEmpty()
+  nome: string;
+
+  @IsString() @IsNotEmpty()
+  cidade: string;
+}

--- a/bookstore-api-JMarani-main/src/editora/dto/update-editora.dto.ts
+++ b/bookstore-api-JMarani-main/src/editora/dto/update-editora.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateEditoraDto } from './create-editora.dto';
+
+export class UpdateEditoraDto extends PartialType(CreateEditoraDto) {}

--- a/bookstore-api-JMarani-main/src/editora/editora.controller.ts
+++ b/bookstore-api-JMarani-main/src/editora/editora.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Post, Get, Patch, Delete, Body, Param, ParseIntPipe } from '@nestjs/common';
+import { EditoraService } from './editora.service';
+import { CreateEditoraDto } from './dto/create-editora.dto';
+import { UpdateEditoraDto } from './dto/update-editora.dto';
+
+@Controller('editoras')
+export class EditoraController {
+  constructor(private readonly service: EditoraService) {}
+
+  @Post()
+  create(@Body() dto: CreateEditoraDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.service.findOne(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateEditoraDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.service.remove(id);
+  }
+}

--- a/bookstore-api-JMarani-main/src/editora/editora.entity.ts
+++ b/bookstore-api-JMarani-main/src/editora/editora.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
+import { Livro } from '../livro/livro.entity';
+
+@Entity('editoras')
+export class Editora {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  nome: string;
+
+  @Column()
+  cidade: string;
+
+  @OneToMany(() => Livro, livro => livro.editora)
+  livros: Livro[];
+}

--- a/bookstore-api-JMarani-main/src/editora/editora.module.ts
+++ b/bookstore-api-JMarani-main/src/editora/editora.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Editora } from './editora.entity';
+import { EditoraService } from './editora.service';
+import { EditoraController } from './editora.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Editora])],
+  controllers: [EditoraController],
+  providers: [EditoraService],
+})
+export class EditoraModule {}

--- a/bookstore-api-JMarani-main/src/editora/editora.service.ts
+++ b/bookstore-api-JMarani-main/src/editora/editora.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Editora } from './editora.entity';
+import { CreateEditoraDto } from './dto/create-editora.dto';
+import { UpdateEditoraDto } from './dto/update-editora.dto';
+
+@Injectable()
+export class EditoraService {
+  constructor(@InjectRepository(Editora) private repo: Repository<Editora>) {}
+
+  create(dto: CreateEditoraDto) {
+    const editora = this.repo.create(dto);
+    return this.repo.save(editora);
+  }
+
+  findAll() {
+    return this.repo.find();
+  }
+
+  async findOne(id: number) {
+    const editora = await this.repo.findOne({ where: { id } });
+    if (!editora) throw new NotFoundException(`Editora #${id} não encontrada`);
+    return editora;
+  }
+
+  async update(id: number, dto: UpdateEditoraDto) {
+    const editora = await this.findOne(id);
+    Object.assign(editora, dto);
+    return this.repo.save(editora);
+  }
+
+  async remove(id: number) {
+    const editora = await this.findOne(id);
+    return this.repo.remove(editora);
+  }
+}

--- a/bookstore-api-JMarani-main/src/livro/dto/create-livro.dto.ts
+++ b/bookstore-api-JMarani-main/src/livro/dto/create-livro.dto.ts
@@ -1,0 +1,18 @@
+import { IsInt, IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateLivroDto {
+  @IsString() @IsNotEmpty()
+  titulo: string;
+
+  @IsInt()
+  anoPublicacao: number;
+
+  @IsString() @IsNotEmpty()
+  isbn: string;
+
+  @IsInt()
+  autorId: number;
+
+  @IsInt()
+  editoraId: number;
+}

--- a/bookstore-api-JMarani-main/src/livro/dto/update-livro.dto.ts
+++ b/bookstore-api-JMarani-main/src/livro/dto/update-livro.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateLivroDto } from './create-livro.dto';
+
+export class UpdateLivroDto extends PartialType(CreateLivroDto) {}

--- a/bookstore-api-JMarani-main/src/livro/livro.controller.ts
+++ b/bookstore-api-JMarani-main/src/livro/livro.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Post, Get, Patch, Delete, Body, Param, ParseIntPipe } from '@nestjs/common';
+import { LivroService } from './livro.service';
+import { CreateLivroDto } from './dto/create-livro.dto';
+import { UpdateLivroDto } from './dto/update-livro.dto';
+
+@Controller('livros')
+export class LivroController {
+  constructor(private readonly service: LivroService) {}
+
+  @Post()
+  create(@Body() dto: CreateLivroDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.service.findOne(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateLivroDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.service.remove(id);
+  }
+}

--- a/bookstore-api-JMarani-main/src/livro/livro.entity.ts
+++ b/bookstore-api-JMarani-main/src/livro/livro.entity.ts
@@ -1,0 +1,28 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, OneToMany } from 'typeorm';
+import { Autor } from '../autor/autor.entity';
+import { Editora } from '../editora/editora.entity';
+import { BookReview } from '../book-review/book-review.entity';
+
+@Entity('livros')
+export class Livro {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  titulo: string;
+
+  @Column()
+  anoPublicacao: number;
+
+  @Column()
+  isbn: string;
+
+  @ManyToOne(() => Autor, autor => autor.livros)
+  autor: Autor;
+
+  @ManyToOne(() => Editora, editora => editora.livros)
+  editora: Editora;
+
+  @OneToMany(() => BookReview, review => review.livro, { cascade: true })
+  reviews: BookReview[];
+}

--- a/bookstore-api-JMarani-main/src/livro/livro.module.ts
+++ b/bookstore-api-JMarani-main/src/livro/livro.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Livro } from './livro.entity';
+import { LivroService } from './livro.service';
+import { LivroController } from './livro.controller';
+import { Autor } from '../autor/autor.entity';
+import { Editora } from '../editora/editora.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Livro, Autor, Editora])],
+  controllers: [LivroController],
+  providers: [LivroService],
+})
+export class LivroModule {}

--- a/bookstore-api-JMarani-main/src/livro/livro.service.ts
+++ b/bookstore-api-JMarani-main/src/livro/livro.service.ts
@@ -1,0 +1,63 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Livro } from './livro.entity';
+import { Autor } from '../autor/autor.entity';
+import { Editora } from '../editora/editora.entity';
+import { CreateLivroDto } from './dto/create-livro.dto';
+import { UpdateLivroDto } from './dto/update-livro.dto';
+
+@Injectable()
+export class LivroService {
+  constructor(
+    @InjectRepository(Livro) private repo: Repository<Livro>,
+    @InjectRepository(Autor) private autorRepo: Repository<Autor>,
+    @InjectRepository(Editora) private editoraRepo: Repository<Editora>,
+  ) {}
+
+  async create(dto: CreateLivroDto) {
+    const autor = await this.autorRepo.findOne({ where: { id: dto.autorId } });
+    if (!autor) throw new NotFoundException(`Autor #${dto.autorId} não encontrado`);
+    const editora = await this.editoraRepo.findOne({ where: { id: dto.editoraId } });
+    if (!editora) throw new NotFoundException(`Editora #${dto.editoraId} não encontrada`);
+    const livro = this.repo.create({
+      titulo: dto.titulo,
+      anoPublicacao: dto.anoPublicacao,
+      isbn: dto.isbn,
+      autor,
+      editora,
+    });
+    return this.repo.save(livro);
+  }
+
+  findAll() {
+    return this.repo.find({ relations: ['autor', 'editora'] });
+  }
+
+  async findOne(id: number) {
+    const livro = await this.repo.findOne({ where: { id }, relations: ['autor', 'editora', 'reviews'] });
+    if (!livro) throw new NotFoundException(`Livro #${id} não encontrado`);
+    return livro;
+  }
+
+  async update(id: number, dto: UpdateLivroDto) {
+    const livro = await this.findOne(id);
+    if (dto.autorId) {
+      const autor = await this.autorRepo.findOne({ where: { id: dto.autorId } });
+      if (!autor) throw new NotFoundException(`Autor #${dto.autorId} não encontrado`);
+      livro.autor = autor;
+    }
+    if (dto.editoraId) {
+      const editora = await this.editoraRepo.findOne({ where: { id: dto.editoraId } });
+      if (!editora) throw new NotFoundException(`Editora #${dto.editoraId} não encontrada`);
+      livro.editora = editora;
+    }
+    Object.assign(livro, dto);
+    return this.repo.save(livro);
+  }
+
+  async remove(id: number) {
+    const livro = await this.findOne(id);
+    return this.repo.remove(livro);
+  }
+}


### PR DESCRIPTION
## Summary
- refactor BookReview entity to reference Livro
- add modules and CRUD for Autor, Editora and Livro
- wire up Livro with Autor, Editora and BookReview
- expose REST endpoints for the new resources
- register new entities/modules in app.module

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ea21bc448321b28a87675649507c